### PR TITLE
fix: rename deprecated xorg packages

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -46,12 +46,12 @@ let
     runtimeDependencies = with pkgs; [
       libGL
       libxkbcommon
-      xorg.libX11
-      xorg.libXcomposite
-      xorg.libXdamage
-      xorg.libXext
-      xorg.libXfixes
-      xorg.libXrandr
+      libX11
+      libXcomposite
+      libXdamage
+      libXext
+      libXfixes
+      libXrandr
     ];
 
     # No build phase needed - just unpack and install
@@ -110,18 +110,18 @@ let
       egl-wayland
 
       # X11 (SDL3 dlopens these)
-      xorg.libX11
-      xorg.libXcomposite
-      xorg.libXdamage
-      xorg.libXext
-      xorg.libXfixes
-      xorg.libXrandr
-      xorg.libXcursor
-      xorg.libXi
-      xorg.libxcb
-      xorg.libXScrnSaver
-      xorg.libXinerama
-      xorg.libXxf86vm
+      libX11
+      libXcomposite
+      libXdamage
+      libXext
+      libXfixes
+      libXrandr
+      libXcursor
+      libXi
+      libxcb
+      libXScrnSaver
+      libXinerama
+      libXxf86vm
 
       # Wayland (SDL3 can use Wayland backend)
       wayland


### PR DESCRIPTION
The xorg package set has been deprecated in nixpkgs. 
This renames the affected packages to their new names to fix evaluation warnings.

e.g. xorg.libX11 → libx11