### PR TITLE
Added filesystem fix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -161,8 +161,9 @@ let
       LAUNCHER_BIN="$LAUNCHER_DIR/hytale-launcher"
       BUNDLED_HASH_FILE="$LAUNCHER_DIR/.bundled_hash"
       BUNDLED_BIN="${hytale-launcher-unwrapped}/lib/hytale-launcher/hytale-launcher"
+      LAUNCHER_TMP_DIR="$LAUNCHER_DIR/.tmp"
 
-      mkdir -p "$LAUNCHER_DIR"
+      mkdir -p "$LAUNCHER_DIR" "$LAUNCHER_TMP_DIR"
 
       # Compute hash of bundled binary to detect Nix package updates
       BUNDLED_HASH=$(sha256sum "$BUNDLED_BIN" | cut -d" " -f1)
@@ -185,6 +186,11 @@ let
 
       # SSL certificates
       export SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
+
+      # Keep patch staging on the same filesystem as launcher data
+      # XDG_CACHE_HOME takes precedence over TMPDIR in the launcher
+      unset XDG_CACHE_HOME
+      export TMPDIR="$LAUNCHER_TMP_DIR"
 
       exec "$LAUNCHER_BIN" "$@"
     '';

--- a/package.nix
+++ b/package.nix
@@ -161,7 +161,7 @@ let
       LAUNCHER_BIN="$LAUNCHER_DIR/hytale-launcher"
       BUNDLED_HASH_FILE="$LAUNCHER_DIR/.bundled_hash"
       BUNDLED_BIN="${hytale-launcher-unwrapped}/lib/hytale-launcher/hytale-launcher"
-      LAUNCHER_TMP_DIR="$LAUNCHER_DIR/.tmp"
+      LAUNCHER_TMP_DIR="$LAUNCHER_DIR/.nix-tmp"
 
       mkdir -p "$LAUNCHER_DIR" "$LAUNCHER_TMP_DIR"
 


### PR DESCRIPTION
Fixes: https://github.com/JPyke3/hytale-launcher-nix/issues/62

Reported issues with `/tmp` Filesystems.

Explaination from issue for context:

> We are running in a buildFHSEnv which is a bind mount on /tmp. The launcher first checks if /tmp and ~/.local/share/Hytale/ are on different FS' likely via a statfs. Because buildFHSEnv is bind mounting, the stat will say it's the same filesystem. However, when the rename command happens, it'll care about the bind mount because /tmp would be mounted as a tmpfs.

Waiting on user validation before merging.